### PR TITLE
feat: create initial dashboard structure with layout and base pages

### DIFF
--- a/src/app/(panel)/dashboard/layout.tsx
+++ b/src/app/(panel)/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <>{children}</>;
+}

--- a/src/app/(panel)/dashboard/plans/page.tsx
+++ b/src/app/(panel)/dashboard/plans/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function PlansPage() {
+  return <div>PlansPage</div>;
+}

--- a/src/app/(panel)/dashboard/profile/page.tsx
+++ b/src/app/(panel)/dashboard/profile/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ProfilePage() {
+  return <div>ProfilePage</div>;
+}

--- a/src/app/(panel)/dashboard/services/page.tsx
+++ b/src/app/(panel)/dashboard/services/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ServicesPage() {
+  return <div>ServicesPage</div>;
+}


### PR DESCRIPTION
- Added folder src/app/(panel)/dashboard/ for dashboard module
- Implemented layout.tsx rendering {children}
- Created main page: dashboard/page.tsx with title "Dashboard"
- Added base section pages: • plans/page.tsx → "PlansPage" • profile/page.tsx → "ProfilePage" • services/page.tsx → "ServicesPage"
- Prepared structure for future navigation and features